### PR TITLE
[Style/#23] - 회원가입 페이지 레이아웃 구현

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -14,8 +14,8 @@ const Register = () => {
           placeholder="이메일을 입력해주세요."
           required
         />
-        <button>중복확인</button>
-        <p className="">이메일 에러</p>
+        <button className="bg-slate-300">중복확인</button>
+        <p className="text-red-500">이메일 에러</p>
       </div>
 
       <label className="text-md" htmlFor="nickname">
@@ -28,7 +28,8 @@ const Register = () => {
           placeholder="닉네임을 입력해주세요."
           required
         />
-        <button>중복확인</button>
+        <button className="bg-slate-300">중복확인</button>
+        <p className="text-red-500">닉네임 에러</p>
       </div>
       <label className="text-md" htmlFor="password">
         비밀번호
@@ -39,6 +40,7 @@ const Register = () => {
         placeholder="비밀번호를 입력해주세요."
         required
       />
+      <p className="text-red-500">비밀번호 에러</p>
       <label className="text-md" htmlFor="check-password">
         비밀번호 확인
       </label>
@@ -48,13 +50,14 @@ const Register = () => {
         placeholder="비밀번호를 한번 더입력해주세요."
         required
       />
+      <p className="text-red-500">비밀번호 확인 에러</p>
       <button>회원가입</button>
       <div className="flex flex-col gap-2">
         <p className="text-center">간편 가입하기</p>
-        <button>카카오톡으로 회원가입</button>
-        <button>구글로 회원가입</button>
-        <button>깃헙으로 회원가입</button>
-        <button>페이스북으로 회원가입</button>
+        <button className="bg-slate-300">카카오톡으로 회원가입</button>
+        <button className="bg-slate-300">구글로 회원가입</button>
+        <button className="bg-slate-300">깃헙으로 회원가입</button>
+        <button className="bg-slate-300">페이스북으로 회원가입</button>
       </div>
     </form>
   );

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,7 +1,63 @@
 import React from "react";
 
 const Register = () => {
-  return <div>회원가입</div>;
+  return (
+    <form className="flex flex-col justify-center flex-1 w-2/3 gap-2 p-4 m-4">
+      <h1 className="text-center">회원가입</h1>
+      <label className="text-md" htmlFor="email">
+        이메일
+      </label>
+      <div>
+        <input
+          className="px-4 py-2 mb-6 border rounded-md bg-inherit"
+          name="email"
+          placeholder="이메일을 입력해주세요."
+          required
+        />
+        <button>중복확인</button>
+        <p className="">이메일 에러</p>
+      </div>
+
+      <label className="text-md" htmlFor="nickname">
+        닉네임
+      </label>
+      <div>
+        <input
+          className="px-4 py-2 mb-6 border rounded-md bg-inherit"
+          name="nickname"
+          placeholder="닉네임을 입력해주세요."
+          required
+        />
+        <button>중복확인</button>
+      </div>
+      <label className="text-md" htmlFor="password">
+        비밀번호
+      </label>
+      <input
+        className="px-4 py-2 mb-6 border rounded-md bg-inherit"
+        name="password"
+        placeholder="비밀번호를 입력해주세요."
+        required
+      />
+      <label className="text-md" htmlFor="check-password">
+        비밀번호 확인
+      </label>
+      <input
+        className="px-4 py-2 mb-6 border rounded-md bg-inherit"
+        name="password"
+        placeholder="비밀번호를 한번 더입력해주세요."
+        required
+      />
+      <button>회원가입</button>
+      <div className="flex flex-col gap-2">
+        <p className="text-center">간편 가입하기</p>
+        <button>카카오톡으로 회원가입</button>
+        <button>구글로 회원가입</button>
+        <button>깃헙으로 회원가입</button>
+        <button>페이스북으로 회원가입</button>
+      </div>
+    </form>
+  );
 };
 
 export default Register;


### PR DESCRIPTION
## 📌 관련 이슈
closed #23

## Task TODOLIST
- [X] 회원가입 제목
- [X] 이메일 라벨, 이메일 입력, 이메일 중복확인 버튼, 이메일 에러 메시지
- [X] 닉네임 라벨, 닉네임 입력, 닉네임 중복확인 버튼, 닉네임 에러 메시지
- [X] 비밀번호 입력, 비밀번호 에러 메시지
- [X] 비밀번호 확인 입력, 비밀번호 확인 에러 메시지
- [X] 회원가입 버튼
- [X] 간편 회원가입 버튼

## ✨ 개발 내용
회원가입 제목, 이메일, 닉네임, 비밀번호, 비밀번호 확인 구현, 회원가입

##  TroubleShotting
회원가입에도 간편 회원가입이 필요한지 의견이 나뉘었습니다.
간편 로그인과 간편 로그인은 기능이 완전히 일치했기 때문입니다.
간편 로그인이 필요한지 팀원하고 의논하고 튜터님에게 피드백하였습니다.
그 결과 회원가입에 간편 회원가입을 넣기로 하였습니다.

## 📸 스크린샷
<img src = "https://github.com/TeamSparta-Project/ice-craft/assets/154975499/0d5683bc-5211-49c9-a60e-218946ed7c61" width="250">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
팀원들과 튜터님의 피드백
