### PR TITLE
[Fix #47] room 페이지의 layout 구성 및 컴포넌트 분리

### DIFF
--- a/app/_components/mafia/MyVideoConference.tsx
+++ b/app/_components/mafia/MyVideoConference.tsx
@@ -1,0 +1,134 @@
+import { ParticipantTile, useLocalParticipant, useRemoteParticipants, useTracks } from "@livekit/components-react";
+import { Track } from "livekit-client";
+import React, { useState } from "react";
+
+const MyVideoConference = () => {
+  // 전체 데이터
+  const tracks = useTracks(
+    [
+      { source: Track.Source.Camera, withPlaceholder: true },
+      { source: Track.Source.ScreenShare, withPlaceholder: false }
+    ],
+    { onlySubscribed: false }
+  );
+
+  //클릭시 이미지 보임
+  const [showOverlay, setShowOverlay] = useState<{ [key: string]: boolean }>({});
+
+  // 오버레이 토글 함수
+  const toggleOverlay = (event: any, participantSid: string) => {
+    // console.log(`Event type: ${event.type}`);
+    event.stopPropagation();
+    setShowOverlay((prev) => {
+      const newState = { ...prev, [participantSid]: !prev[participantSid] };
+      return newState;
+    });
+  };
+  // local 정보를 가져온다.
+  const { localParticipant } = useLocalParticipant();
+  const remoteParticipant = useRemoteParticipants();
+
+  // 필터링하여 로컬 및 원격 트랙을 구분
+  // 자신
+  const localTracks = tracks.filter((track) => track.participant.sid === localParticipant.sid)!;
+
+  //나머지 player
+  const remoteTracks = tracks.filter((track) => track.participant.sid !== localParticipant.sid);
+
+  return (
+    <main
+      style={{
+        display: "flex",
+        height: "100%",
+        width: "100%",
+        alignItems: "center",
+        padding: "0 20px",
+        gap: "30px",
+        justifyContent: "space-between"
+      }}
+    >
+      {/* 로컬 참가자 비디오 */}
+      <section style={{ width: "35%", height: "100%" }}>
+        {localTracks.map((track) => (
+          <div
+            key={track.participant.sid}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "50px",
+              justifyContent: "center",
+              marginTop: "150px"
+            }}
+          >
+            <div
+              onClick={(e) => toggleOverlay(e, track.participant.sid)}
+              style={{
+                position: "relative",
+                width: "100%",
+                height: "100%",
+                overflow: "hidden",
+                borderRadius: "8px"
+              }}
+            >
+              <ParticipantTile trackRef={track} />
+              {showOverlay[track.participant.sid] && (
+                <div
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: "100%",
+                    backgroundColor: "red",
+                    opacity: "0.7"
+                  }}
+                >
+                  테스트당
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      {/* 원격 참가자 비디오 */}
+      <section
+        style={{
+          width: "65%",
+          display: "flex",
+          alignItems: "baseline",
+          gap: "10px",
+          flexWrap: "wrap",
+          justifyContent: "flex-start",
+          height: "100%"
+        }}
+      >
+        {remoteTracks.map((track, index) => (
+          <div
+            onClick={(e) => toggleOverlay(e, track.participant.sid)}
+            style={{ position: "relative", overflow: "hidden", borderRadius: "8px" }}
+          >
+            <ParticipantTile key={index} trackRef={track} style={{ width: "300px", height: "200px" }} />
+            {showOverlay[track.participant.sid] && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "300px",
+                  height: "200px",
+                  backgroundColor: "red",
+                  opacity: "0.6"
+                }}
+              >
+                테스트다
+              </div>
+            )}
+          </div>
+        ))}
+      </section>
+    </main>
+  );
+};
+
+export default MyVideoConference;

--- a/app/room/[id]/page.tsx
+++ b/app/room/[id]/page.tsx
@@ -1,230 +1,28 @@
-"use client";
+import React from "react";
+("use client");
 
+import MyVideoConference from "@/app/_components/mafia/MyVideoConference";
 import Timer from "@/app/_components/mafia/Timer";
-import { useGetToken } from "@/app/_hooks/useToken";
 import { useModalStore } from "@/app/_store/modal-store";
-import {
-  LiveKitRoom,
-  ParticipantTile,
-  RoomAudioRenderer,
-  useLocalParticipant,
-  useParticipantTracks,
-  useRemoteParticipant,
-  useRemoteParticipants,
-  useTracks
-} from "@livekit/components-react";
+import { useParticipantTracks, useRemoteParticipant, useTracks } from "@livekit/components-react";
 import "@livekit/components-styles";
-import { Track } from "livekit-client";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useRouter } from "next/navigation";
 
-export default function RoomPage() {
-  const params = useSearchParams();
+const RoomPage = () => {
   const routers = useRouter();
-
+  const tracks = useTracks();
   const { isModal, setIsModal } = useModalStore();
+  const RemoteParticipant = useRemoteParticipant("identity"); //현재 방의 특정 원격 참가자
 
-  const room = params.get("room");
-  const name = params.get("name");
-
-  if (!room || !name) {
-    return;
-  }
-
-  const { data: token, isLoading, isError } = useGetToken({ room, name });
-
-  if (isLoading) {
-    console.log("로딩중");
-  }
-
-  if (isError) {
-    console.log(isError);
-  }
+  const sources = tracks.map((item) => {
+    return item.source;
+  });
+  const ParticipantTrack = useParticipantTracks(sources, "identity");
 
   //토큰을 별도로 저장하고 있지 않기에 임시로 route 변경
   const deleteToken = () => {
     routers.replace(`/room`);
   };
-
-  return (
-    <>
-      <div>
-        <button
-          onClick={() => {
-            setIsModal(true);
-          }}
-        >
-          타이머 버튼 클릭
-        </button>
-      </div>
-
-      <LiveKitRoom
-        token={token} // 필수 요소
-        serverUrl={process.env.NEXT_PUBLIC_LIVEKIT_URL} // 필수 요소
-        video={true}
-        audio={true}
-        onDisconnected={deleteToken} //연결 중단 시 발생하는 이벤트 핸들러
-        data-lk-theme="default"
-        // simulateParticipants={5} // 테스트용 카메라 생성
-        style={{ height: "100vh", width: "100vw" }}
-      >
-        <CamOrVideo />
-        <MyVideoConference />
-        {isModal ? (
-          <div className="w-full h-screen bg-black bg-opacity-60 fixed z-1 top-0 left-0 flex justify-center items-center">
-            <div className="flex flex-col justify-center items-center bg-white p-5 border border-solid border-gray-300 rounded-lg">
-              <div className="w-96 h-96 p-5 block">
-                <p className="text-6xl text-black"> 밤이 시작되었습니다.</p>
-              </div>
-              <Timer />
-            </div>
-          </div>
-        ) : null}
-        <RoomAudioRenderer />
-      </LiveKitRoom>
-    </>
-  );
-}
-
-function MyVideoConference() {
-  // 전체 데이터
-  const tracks = useTracks(
-    [
-      { source: Track.Source.Camera, withPlaceholder: true },
-      { source: Track.Source.ScreenShare, withPlaceholder: false }
-    ],
-    { onlySubscribed: false }
-  );
-
-  //클릭시 이미지 보임
-  const [showOverlay, setShowOverlay] = useState<{ [key: string]: boolean }>({});
-
-  // 오버레이 토글 함수
-  const toggleOverlay = (event: any, participantSid: string) => {
-    // console.log(`Event type: ${event.type}`);
-    event.stopPropagation();
-    setShowOverlay((prev) => {
-      const newState = { ...prev, [participantSid]: !prev[participantSid] };
-      return newState;
-    });
-  };
-  // local 정보를 가져온다.
-  const { localParticipant } = useLocalParticipant();
-  const remoteParticipant = useRemoteParticipants();
-
-  // 필터링하여 로컬 및 원격 트랙을 구분
-  // 자신
-  const localTracks = tracks.filter((track) => track.participant.sid === localParticipant.sid)!;
-
-  //나머지 player
-  const remoteTracks = tracks.filter((track) => track.participant.sid !== localParticipant.sid);
-
-  return (
-    <main
-      style={{
-        display: "flex",
-        height: "100%",
-        width: "100%",
-        alignItems: "center",
-        padding: "0 20px",
-        gap: "30px",
-        justifyContent: "space-between"
-      }}
-    >
-      {/* 로컬 참가자 비디오 */}
-      <section style={{ width: "35%", height: "100%" }}>
-        {localTracks.map((track) => (
-          <div
-            key={track.participant.sid}
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "50px",
-              justifyContent: "center",
-              marginTop: "150px"
-            }}
-          >
-            <div
-              onClick={(e) => toggleOverlay(e, track.participant.sid)}
-              style={{
-                position: "relative",
-                width: "100%",
-                height: "100%",
-                overflow: "hidden",
-                borderRadius: "8px"
-              }}
-            >
-              <ParticipantTile trackRef={track} />
-              {showOverlay[track.participant.sid] && (
-                <div
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    height: "100%",
-                    backgroundColor: "red",
-                    opacity: "0.7"
-                  }}
-                >
-                  테스트당
-                </div>
-              )}
-            </div>
-          </div>
-        ))}
-      </section>
-
-      {/* 원격 참가자 비디오 */}
-      <section
-        style={{
-          width: "65%",
-          display: "flex",
-          alignItems: "baseline",
-          gap: "10px",
-          flexWrap: "wrap",
-          justifyContent: "flex-start",
-          height: "100%"
-        }}
-      >
-        {remoteTracks.map((track, index) => (
-          <div
-            onClick={(e) => toggleOverlay(e, track.participant.sid)}
-            style={{ position: "relative", overflow: "hidden", borderRadius: "8px" }}
-          >
-            <ParticipantTile key={index} trackRef={track} style={{ width: "300px", height: "200px" }} />
-            {showOverlay[track.participant.sid] && (
-              <div
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "300px",
-                  height: "200px",
-                  backgroundColor: "red",
-                  opacity: "0.6"
-                }}
-              >
-                테스트다
-              </div>
-            )}
-          </div>
-        ))}
-      </section>
-    </main>
-  );
-}
-
-const CamOrVideo = () => {
-  const RemoteParticipant = useRemoteParticipant("identity"); //현재 방의 특정 원격 참가자
-
-  //모든 트랙(데이터) 가져오기
-  const tracks = useTracks();
-  const sources = tracks.map((item) => {
-    return item.source;
-  });
-
-  const ParticipantTrack = useParticipantTracks(sources, "identity");
 
   //NOTE -  모든 유저 마이크만 off
   const AllMikeOff = () => {
@@ -258,9 +56,6 @@ const CamOrVideo = () => {
 
   //NOTE -  전체 캠 및 오디오 on
   const allCamOn = () => {
-    //죽은 유저를 제외한 tracks 가져오기
-    const lifeTrack = tracks.filter((item) => item.participant.sid === "dieUser.sid");
-
     tracks.forEach((track) => {
       const trackOn = track.publication.track;
       if (trackOn) {
@@ -282,6 +77,15 @@ const CamOrVideo = () => {
   return (
     <>
       <div>
+        <button
+          onClick={() => {
+            setIsModal(true);
+          }}
+        >
+          타이머 버튼 클릭
+        </button>
+      </div>
+      <div>
         <button onClick={AllMikeOff}> 투표 시간 </button>
       </div>
       <div>
@@ -293,6 +97,20 @@ const CamOrVideo = () => {
       <div>
         <button onClick={allCamOff}>전체 캠 및 오디오 off </button>
       </div>
+
+      <MyVideoConference />
+      {isModal ? (
+        <div className="w-full h-screen bg-black bg-opacity-60 fixed z-1 top-0 left-0 flex justify-center items-center">
+          <div className="flex flex-col justify-center items-center bg-white p-5 border border-solid border-gray-300 rounded-lg">
+            <div className="w-96 h-96 p-5 block">
+              <p className="text-6xl text-black"> 밤이 시작되었습니다.</p>
+            </div>
+            <Timer />
+          </div>
+        </div>
+      ) : null}
     </>
   );
 };
+
+export default RoomPage;

--- a/app/room/layout.tsx
+++ b/app/room/layout.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { LiveKitRoom, RoomAudioRenderer } from "@livekit/components-react";
+import { useSearchParams } from "next/navigation";
+import { PropsWithChildren } from "react";
+import { useGetToken } from "../_hooks/useToken";
+
+const layout = ({ children }: PropsWithChildren) => {
+  const params = useSearchParams();
+  const room = params.get("room");
+  const name = params.get("name");
+
+  if (!room || !name) {
+    console.log("useSearchParams의 인자 error 발생 ");
+    return;
+  }
+  const { data: token, isLoading, isSuccess, isError } = useGetToken({ room, name });
+
+  if (isLoading || !isSuccess) {
+    console.log("token 발급 로딩중 발생");
+    return;
+  }
+  if (isError) {
+    console.log("token 발급 로딩중 발생");
+    return;
+  }
+
+  return (
+    <LiveKitRoom
+      token={token} // 필수 요소
+      serverUrl={process.env.NEXT_PUBLIC_LIVEKIT_URL} // 필수 요소
+      video={true}
+      audio={true}
+      data-lk-theme="default"
+      // simulateParticipants={5} // 테스트용 카메라 생성
+      style={{ height: "100vh", width: "100vw" }}
+    >
+      {children}
+      <RoomAudioRenderer />
+    </LiveKitRoom>
+  );
+};
+
+export default layout;


### PR DESCRIPTION
## 📌 관련 이슈
  closed #47 

## Task TODOLIST
- [x] room 페이지 기능별 컴포넌트 분리
- [x] layout.tsx로 분리

## ✨ 개발 내용
LiveKit에서 제공하는 컴포넌트 및 hooks의 scope를 넓히기 위해
Static routing에서  layout.tsx를 생성하여 LiveKitRoom의 컴포넌트를 별도로 관리하였습니다.

```
//layout.tsx

    <LiveKitRoom
      token={token} // 필수 요소
      serverUrl={process.env.NEXT_PUBLIC_LIVEKIT_URL} // 필수 요소
      video={true}
      audio={true}
      data-lk-theme="default"
      // simulateParticipants={5} // 테스트용 카메라 생성
      style={{ height: "100vh", width: "100vw" }}
    >
      {children}
      <RoomAudioRenderer />
    </LiveKitRoom>
```
